### PR TITLE
Add calendar view to Allergen History screen

### DIFF
--- a/src/components/AllergenHistory.css
+++ b/src/components/AllergenHistory.css
@@ -1,0 +1,153 @@
+.allergen-history {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 20px;
+}
+
+.history-header h2 {
+  font-size: 24px;
+  font-weight: 600;
+  margin-bottom: 20px;
+  color: #111827;
+}
+
+.month-navigation {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 20px;
+  padding: 12px;
+  background: white;
+  border-radius: 8px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+.month-navigation h3 {
+  font-size: 18px;
+  font-weight: 600;
+  margin: 0;
+  color: #111827;
+}
+
+.nav-button {
+  padding: 8px 16px;
+  background: #3b82f6;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.nav-button:hover {
+  background: #2563eb;
+}
+
+.legend {
+  display: flex;
+  gap: 24px;
+  margin-top: 16px;
+  padding: 12px;
+  background: white;
+  border-radius: 8px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+.legend-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  color: #6b7280;
+}
+
+.legend-marker {
+  font-size: 20px;
+  font-weight: bold;
+}
+
+.legend-marker.normal {
+  color: #3b82f6;
+}
+
+.legend-marker.reaction {
+  color: #ef4444;
+}
+
+.day-details {
+  margin-top: 24px;
+  padding: 20px;
+  background: white;
+  border-radius: 8px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+.day-details h3 {
+  font-size: 18px;
+  font-weight: 600;
+  margin-bottom: 16px;
+  color: #111827;
+}
+
+.entries-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.entry-card {
+  padding: 16px;
+  background: #f9fafb;
+  border-radius: 6px;
+  border-left: 4px solid #3b82f6;
+}
+
+.entry-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+.entry-allergen {
+  font-weight: 600;
+  font-size: 16px;
+  color: #111827;
+}
+
+.reaction-badge {
+  padding: 4px 12px;
+  border-radius: 12px;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: capitalize;
+}
+
+.reaction-badge.mild {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.reaction-badge.moderate {
+  background: #fed7aa;
+  color: #9a3412;
+}
+
+.reaction-badge.severe {
+  background: #fecaca;
+  color: #991b1b;
+}
+
+.entry-notes {
+  margin: 8px 0;
+  color: #6b7280;
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.entry-time {
+  font-size: 12px;
+  color: #9ca3af;
+}

--- a/src/components/AllergenHistory.tsx
+++ b/src/components/AllergenHistory.tsx
@@ -1,0 +1,96 @@
+import { useState } from 'react'
+import type { AllergenEntry, AllergenDay } from '../types'
+import { Calendar } from './Calendar'
+import './AllergenHistory.css'
+
+interface AllergenHistoryProps {
+  allergenName: string
+  allergenDays: AllergenDay[]
+}
+
+export function AllergenHistory({ allergenName, allergenDays }: AllergenHistoryProps) {
+  const [currentDate, setCurrentDate] = useState(new Date())
+  const [selectedDate, setSelectedDate] = useState<string | null>(null)
+
+  const year = currentDate.getFullYear()
+  const month = currentDate.getMonth()
+
+  const handlePreviousMonth = () => {
+    setCurrentDate(new Date(year, month - 1, 1))
+    setSelectedDate(null)
+  }
+
+  const handleNextMonth = () => {
+    setCurrentDate(new Date(year, month + 1, 1))
+    setSelectedDate(null)
+  }
+
+  const handleDayClick = (date: string) => {
+    setSelectedDate(date)
+  }
+
+  const selectedDayData = allergenDays.find((day) => day.date === selectedDate)
+
+  const monthName = currentDate.toLocaleString('default', { month: 'long' })
+
+  return (
+    <div className="allergen-history">
+      <div className="history-header">
+        <h2>{allergenName} Feeding History</h2>
+      </div>
+
+      <div className="month-navigation">
+        <button onClick={handlePreviousMonth} className="nav-button">
+          ← Previous
+        </button>
+        <h3>
+          {monthName} {year}
+        </h3>
+        <button onClick={handleNextMonth} className="nav-button">
+          Next →
+        </button>
+      </div>
+
+      <Calendar
+        year={year}
+        month={month}
+        allergenDays={allergenDays}
+        onDayClick={handleDayClick}
+        selectedDate={selectedDate}
+      />
+
+      <div className="legend">
+        <div className="legend-item">
+          <span className="legend-marker normal">•</span>
+          <span>Normal feeding</span>
+        </div>
+        <div className="legend-item">
+          <span className="legend-marker reaction">★</span>
+          <span>Reaction occurred</span>
+        </div>
+      </div>
+
+      {selectedDayData && (
+        <div className="day-details">
+          <h3>Entries for {selectedDate}</h3>
+          <div className="entries-list">
+            {selectedDayData.entries.map((entry: AllergenEntry) => (
+              <div key={entry.id} className="entry-card">
+                <div className="entry-header">
+                  <span className="entry-allergen">{entry.allergen}</span>
+                  {entry.hasReaction && (
+                    <span className={`reaction-badge ${entry.reactionSeverity || 'mild'}`}>
+                      {entry.reactionSeverity || 'Reaction'}
+                    </span>
+                  )}
+                </div>
+                {entry.notes && <p className="entry-notes">{entry.notes}</p>}
+                {entry.time && <span className="entry-time">{entry.time}</span>}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/Calendar.css
+++ b/src/components/Calendar.css
@@ -1,0 +1,91 @@
+.calendar {
+  background: white;
+  border-radius: 8px;
+  padding: 16px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+.calendar-header {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.day-name {
+  text-align: center;
+  font-weight: 600;
+  font-size: 14px;
+  color: #6b7280;
+  padding: 8px 0;
+}
+
+.calendar-grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 8px;
+}
+
+.calendar-day {
+  aspect-ratio: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  font-size: 14px;
+  position: relative;
+  background: #f9fafb;
+  border: 1px solid #e5e7eb;
+}
+
+.calendar-day.empty {
+  background: transparent;
+  border: none;
+}
+
+.calendar-day.has-entries {
+  cursor: pointer;
+  background: #eff6ff;
+  border-color: #3b82f6;
+}
+
+.calendar-day.has-entries:hover {
+  background: #dbeafe;
+  transform: scale(1.05);
+  transition: all 0.2s;
+}
+
+.calendar-day.selected {
+  background: #3b82f6;
+  color: white;
+  font-weight: 600;
+}
+
+.calendar-day.selected .day-marker {
+  color: white;
+}
+
+.day-number {
+  font-size: 16px;
+}
+
+.day-marker {
+  font-size: 18px;
+  margin-top: 2px;
+  color: #3b82f6;
+}
+
+.calendar-day.has-entries .day-marker {
+  color: #3b82f6;
+}
+
+/* Reaction marker (star) */
+.calendar-day.has-entries:has(.day-marker:contains('★')) {
+  border-color: #ef4444;
+  background: #fef2f2;
+}
+
+.calendar-day.has-entries .day-marker:first-child {
+  color: #ef4444;
+}

--- a/src/components/Calendar.tsx
+++ b/src/components/Calendar.tsx
@@ -1,0 +1,85 @@
+import type { AllergenDay } from '../types'
+import './Calendar.css'
+
+interface CalendarProps {
+  year: number
+  month: number
+  allergenDays: AllergenDay[]
+  onDayClick: (date: string) => void
+  selectedDate: string | null
+}
+
+export function Calendar({ year, month, allergenDays, onDayClick, selectedDate }: CalendarProps) {
+  // Create a map for quick lookup
+  const dayMap = new Map(allergenDays.map((day) => [day.date, day]))
+
+  // Get the first day of the month and total days
+  const firstDay = new Date(year, month, 1)
+  const lastDay = new Date(year, month + 1, 0)
+  const daysInMonth = lastDay.getDate()
+  const startingDayOfWeek = firstDay.getDay() // 0 = Sunday
+
+  // Generate calendar grid
+  const calendarDays: (number | null)[] = []
+
+  // Add empty cells for days before the month starts
+  for (let i = 0; i < startingDayOfWeek; i++) {
+    calendarDays.push(null)
+  }
+
+  // Add the days of the month
+  for (let day = 1; day <= daysInMonth; day++) {
+    calendarDays.push(day)
+  }
+
+  const getDayData = (day: number | null): AllergenDay | undefined => {
+    if (day === null) return undefined
+    const dateStr = `${year}-${String(month + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}`
+    return dayMap.get(dateStr)
+  }
+
+  const formatDate = (day: number): string => {
+    return `${year}-${String(month + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}`
+  }
+
+  return (
+    <div className="calendar">
+      <div className="calendar-header">
+        <div className="day-name">Sun</div>
+        <div className="day-name">Mon</div>
+        <div className="day-name">Tue</div>
+        <div className="day-name">Wed</div>
+        <div className="day-name">Thu</div>
+        <div className="day-name">Fri</div>
+        <div className="day-name">Sat</div>
+      </div>
+      <div className="calendar-grid">
+        {calendarDays.map((day, index) => {
+          if (day === null) {
+            return <div key={`empty-${index}`} className="calendar-day empty"></div>
+          }
+
+          const dayData = getDayData(day)
+          const dateStr = formatDate(day)
+          const isSelected = selectedDate === dateStr
+          const hasEntries = dayData && dayData.entries.length > 0
+
+          return (
+            <div
+              key={day}
+              className={`calendar-day ${hasEntries ? 'has-entries' : ''} ${isSelected ? 'selected' : ''}`}
+              onClick={() => hasEntries && onDayClick(dateStr)}
+            >
+              <span className="day-number">{day}</span>
+              {hasEntries && (
+                <span className="day-marker">
+                  {dayData.hasReaction ? '★' : '•'}
+                </span>
+              )}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/src/components/history/HistoryView.tsx
+++ b/src/components/history/HistoryView.tsx
@@ -3,7 +3,8 @@ import { useTranslation } from 'react-i18next'
 import { useFeedingLogs, useAllergens } from '../../hooks/useDatabase'
 import { HistoryItem } from './HistoryItem'
 import { Select } from '../common'
-import type { AllergenType } from '../../types'
+import type { AllergenType, AllergenDay, AllergenEntry } from '../../types'
+import { AllergenHistory } from '../AllergenHistory'
 
 export function HistoryView() {
   const { t } = useTranslation()
@@ -11,6 +12,7 @@ export function HistoryView() {
   const { data: allergens } = useAllergens()
   const [filterAllergen, setFilterAllergen] = useState<AllergenType | 'all'>('all')
   const [reactionsOnly, setReactionsOnly] = useState(false)
+  const [viewMode, setViewMode] = useState<'list' | 'calendar'>('list')
 
   const filteredLogs = useMemo(() => {
     if (!allLogs) return []
@@ -43,6 +45,43 @@ export function HistoryView() {
     return options
   }, [allergens, t])
 
+  // Convert feeding logs to AllergenDay format for calendar
+  const allergenDays = useMemo(() => {
+    if (!filteredLogs) return []
+
+    const daysMap = new Map<string, AllergenEntry[]>()
+
+    filteredLogs.forEach((log) => {
+      const date = log.date.split('T')[0] // Get YYYY-MM-DD part
+      if (!daysMap.has(date)) {
+        daysMap.set(date, [])
+      }
+
+      const allergen = allergens?.find((a) => a.type === log.allergen)
+      const entry: AllergenEntry = {
+        id: log.id,
+        allergen: allergen ? `${allergen.emoji} ${allergen.name}` : log.allergen,
+        hasReaction: log.hasReaction,
+        reactionSeverity: log.reactionSeverity,
+        notes: log.notes,
+        time: new Date(log.date).toLocaleTimeString('en-US', {
+          hour: '2-digit',
+          minute: '2-digit',
+        }),
+      }
+
+      daysMap.get(date)!.push(entry)
+    })
+
+    const days: AllergenDay[] = Array.from(daysMap.entries()).map(([date, entries]) => ({
+      date,
+      entries,
+      hasReaction: entries.some((e) => e.hasReaction),
+    }))
+
+    return days
+  }, [filteredLogs, allergens])
+
   if (isLoading) {
     return (
       <div className="flex justify-center items-center py-12">
@@ -50,6 +89,12 @@ export function HistoryView() {
       </div>
     )
   }
+
+  const selectedAllergenName = useMemo(() => {
+    if (filterAllergen === 'all') return 'All Allergens'
+    const allergen = allergens?.find((a) => a.type === filterAllergen)
+    return allergen ? `${allergen.emoji} ${allergen.name}` : filterAllergen
+  }, [filterAllergen, allergens])
 
   return (
     <div className="space-y-4">
@@ -62,39 +107,80 @@ export function HistoryView() {
           options={allergenOptions}
         />
 
-        <label className="flex items-center gap-2 cursor-pointer">
-          <input
-            type="checkbox"
-            checked={reactionsOnly}
-            onChange={(e) => setReactionsOnly(e.target.checked)}
-            className="w-5 h-5 text-primary focus:ring-primary border-gray-300 rounded"
-          />
-          <span className="text-sm font-medium text-gray-700">
-            {t('history.reactionsOnly')}
-          </span>
-        </label>
+        <div className="flex items-center justify-between">
+          <label className="flex items-center gap-2 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={reactionsOnly}
+              onChange={(e) => setReactionsOnly(e.target.checked)}
+              className="w-5 h-5 text-primary focus:ring-primary border-gray-300 rounded"
+            />
+            <span className="text-sm font-medium text-gray-700">
+              {t('history.reactionsOnly')}
+            </span>
+          </label>
+
+          <div className="flex gap-2">
+            <button
+              onClick={() => setViewMode('list')}
+              className={`px-3 py-1 text-sm rounded ${
+                viewMode === 'list'
+                  ? 'bg-primary text-white'
+                  : 'bg-gray-200 text-gray-700'
+              }`}
+            >
+              📝 List
+            </button>
+            <button
+              onClick={() => setViewMode('calendar')}
+              className={`px-3 py-1 text-sm rounded ${
+                viewMode === 'calendar'
+                  ? 'bg-primary text-white'
+                  : 'bg-gray-200 text-gray-700'
+              }`}
+            >
+              📅 Calendar
+            </button>
+          </div>
+        </div>
       </div>
 
-      {/* History List */}
-      {filteredLogs.length === 0 ? (
-        <div className="text-center py-12">
-          <div className="text-4xl mb-4">📝</div>
-          <p className="text-gray-600">
-            {filterAllergen !== 'all' || reactionsOnly
-              ? t('history.noLogsForAllergen')
-              : t('history.noLogs')}
-          </p>
-        </div>
+      {/* Content - Calendar or List View */}
+      {viewMode === 'calendar' ? (
+        filteredLogs.length === 0 ? (
+          <div className="text-center py-12">
+            <div className="text-4xl mb-4">📅</div>
+            <p className="text-gray-600">
+              {filterAllergen !== 'all' || reactionsOnly
+                ? t('history.noLogsForAllergen')
+                : t('history.noLogs')}
+            </p>
+          </div>
+        ) : (
+          <AllergenHistory allergenName={selectedAllergenName} allergenDays={allergenDays} />
+        )
       ) : (
-        <div className="space-y-2">
-          {filteredLogs.map((log) => (
-            <HistoryItem
-              key={log.id}
-              log={log}
-              allergen={allergens?.find((a) => a.type === log.allergen)}
-            />
-          ))}
-        </div>
+        /* List View */
+        filteredLogs.length === 0 ? (
+          <div className="text-center py-12">
+            <div className="text-4xl mb-4">📝</div>
+            <p className="text-gray-600">
+              {filterAllergen !== 'all' || reactionsOnly
+                ? t('history.noLogsForAllergen')
+                : t('history.noLogs')}
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {filteredLogs.map((log) => (
+              <HistoryItem
+                key={log.id}
+                log={log}
+                allergen={allergens?.find((a) => a.type === log.allergen)}
+              />
+            ))}
+          </div>
+        )
       )}
     </div>
   )

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -76,6 +76,22 @@ export const DEFAULT_ALLERGENS: Omit<Allergen, 'id' | 'createdAt' | 'modifiedAt'
   { type: 'seafood', name: 'Seafood', emoji: '🦐', paused: false },
 ]
 
+// Calendar view types
+export interface AllergenEntry {
+  id: string
+  allergen: string
+  hasReaction: boolean
+  reactionSeverity?: ReactionSeverity
+  notes?: string
+  time?: string
+}
+
+export interface AllergenDay {
+  date: string
+  entries: AllergenEntry[]
+  hasReaction: boolean
+}
+
 // Default settings
 export const DEFAULT_SETTINGS: Settings = {
   theme: 'light',


### PR DESCRIPTION
### Summary

Adds a calendar view to the Allergen History screen with proper TypeScript type imports to fix deployment errors.

### Changes
- Added AllergenEntry and AllergenDay types for calendar data
- Created Calendar component with month grid and day marking
- Created AllergenHistory component with navigation and details
- Integrated calendar view into HistoryView with list/calendar toggle
- Fixed TypeScript TS1484 errors using `import type` syntax
- Days with feedings show dots, reaction days show stars
- Clicking marked days displays detailed entries

### Features
- 📅 Monthly calendar grid view
- • Visual markers for feeding days
- ★ Special markers for reaction days
- 🔄 Month navigation
- 🔍 Works with existing allergen and reaction filters
- 🔀 Toggle between list and calendar views

Closes #3

🤖 Generated with [Claude Code](https://claude.ai/code)